### PR TITLE
Detach policies before delete role; add support for stack updates

### DIFF
--- a/lambda-packages/role_handler/jest.config.js
+++ b/lambda-packages/role_handler/jest.config.js
@@ -3,7 +3,7 @@ module.exports = {
     '<rootDir>/test'
   ],
   transform: {
-    '^.+\\.tsx?$': 'ts-jest'
+    // '^.+\\.tsx?$': 'ts-jest'
   },
   testRegex: '(/test/.*|(\\.|/)(test|spec))\\.(ts|js)x?$',
   moduleFileExtensions: [


### PR DESCRIPTION
*Issue #7*

*Description of changes:*

Hi Michael (@otterley),

I'm sending a PR which adds support to the "RoleCreationFunction" Lambda function for
- detaching attached managed policies before deleting a role (changed deleteRole() function)
- support for stack Updates (new updateRole() function:)
- tests for both changes

Jest test output:
```
$ npm test

> role_handler@1.0.0 test
> jest

 PASS  test/handler.test.js
  IAM Role Resource Handler
    ✓ Empty event payload fails (13ms)
    ✓ Bogus operation fails (1ms)
    ✓ Role name generator (1ms)
    ✓ Create operation creates a new Role (24ms)
    ✓ Update operation updates an existing Role (5ms)
    ✓ Delete operation deletes the IAM Role (3ms)

Test Suites: 1 passed, 1 total
Tests:       6 passed, 6 total
Snapshots:   0 total
Time:        0.972s, estimated 1s
Ran all test suites.
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Best regards,
Max
