### PR TITLE
delete all attached and inline policies when deleting a role

### DIFF
--- a/lambda-packages/template.yml
+++ b/lambda-packages/template.yml
@@ -28,6 +28,7 @@ Resources:
           - iam:DetachRolePolicy
           - iam:GetRole
           - iam:ListAttachedRolePolicies
+          - iam:ListRolePolicies
           - iam:ListRoles
           - iam:PutRolePermissionsBoundary
           - iam:PutRolePolicy


### PR DESCRIPTION
Hi Michael (@otterley),

I'm sending this PR which changes the `deleteRole()` function in `lambda-packages/role_handler/index.js` such that it deletes all existing attached or inline policies before deleting the role (not only the ones it has created). This helps when a user has added some permissions to the role manually, which causes the stack delete operation to fail as those policies prevent the role deletion.

Best regards,
Max

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
