### PR TITLE
Fix “Incorrect token audience” error

### DIFF
--- a/lambda-packages/identity_provider_handler/index.js
+++ b/lambda-packages/identity_provider_handler/index.js
@@ -80,7 +80,7 @@ const createProvider = async function (url) {
     // hard-coding this for now to be safe - this is the certificate
     // thumbprint for the EKS OIDC endpoint CA
     ThumbprintList: [eksOIDCCAThumbprint],
-    ClientIDList: ['sts.amazon.com']
+    ClientIDList: ['sts.amazonaws.com']
   }).promise();
   return provider.OpenIDConnectProviderArn;
 };

--- a/lambda-packages/identity_provider_handler/test/handler.test.js
+++ b/lambda-packages/identity_provider_handler/test/handler.test.js
@@ -92,7 +92,7 @@ describe('OIDC Identity Provider Handler', () => {
         sinon.assert.calledWith(createProviderFake, sinon.match({
           Url: testClusterOIDCIssuerURL,
           ThumbprintList: [handler.eksOIDCCAThumbprint],
-          ClientIDList: ['sts.amazon.com']
+          ClientIDList: ['sts.amazonaws.com']
         }));
         expect(request.isDone()).toBe(true);
       });
@@ -164,7 +164,7 @@ describe('OIDC Identity Provider Handler', () => {
         sinon.assert.calledWith(createProviderFake, sinon.match({
           Url: testNewClusterOIDCIssuerURL,
           ThumbprintList: [handler.eksOIDCCAThumbprint],
-          ClientIDList: ['sts.amazon.com']
+          ClientIDList: ['sts.amazonaws.com']
         }));
         expect(request.isDone()).toBe(true);
       });


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
For some reason the audience generated by this repository is not correct, and lead to errors such as:
```
An error occurred (InvalidIdentityToken) when calling the AssumeRoleWithWebIdentity operation: Incorrect token audience
```

This PR fixes the issue by using the correct audience (`sts.amazonaws.com` and not `sts.amazon.com`)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
